### PR TITLE
refactor: clean up utils exports

### DIFF
--- a/ai_dubbing/run_dubbing.py
+++ b/ai_dubbing/run_dubbing.py
@@ -21,7 +21,7 @@ if project_root_str not in sys.path:
     sys.path.append(project_root_str)
 
 # 使用绝对导入
-from ai_dubbing.src.utils.common_utils import setup_project_path
+from ai_dubbing.src.utils import setup_project_path
 from ai_dubbing.src.config import PATH
 from ai_dubbing.src.parsers import SRTParser, TXTParser
 from ai_dubbing.src.strategies import get_strategy, list_available_strategies, get_strategy_description

--- a/ai_dubbing/run_optimize_subtitles.py
+++ b/ai_dubbing/run_optimize_subtitles.py
@@ -21,7 +21,6 @@ if project_root_str not in sys.path:
     sys.path.append(project_root_str)
 
 from ai_dubbing.src.parsers.srt_parser import SRTParser
-from ai_dubbing.src.optimizer.subtitle_optimizer import LLMContextOptimizer
 from ai_dubbing.src.logger import get_logger
 
 def load_config(config_file=str(current_file.parent / "dubbing.conf")):
@@ -111,7 +110,8 @@ def optimize_srt_file(input_path: str, output_path: str = None, config: dict = N
         if not config.get('api_key'):
             logger.error("未配置LLM API密钥，请在 dubbing.conf 文件中设置 llm_api_key")
             return None
-        
+
+        from ai_dubbing.src.optimizer.subtitle_optimizer import LLMContextOptimizer
         optimizer = LLMContextOptimizer(
             api_key=config['api_key'],
             model=config['model'],

--- a/ai_dubbing/src/audio_processor.py
+++ b/ai_dubbing/src/audio_processor.py
@@ -11,7 +11,7 @@ import soundfile as sf
 
 # 使用绝对导入
 from ai_dubbing.src.config import AUDIO
-from ai_dubbing.src.utils.common_utils import create_directory_if_needed
+from ai_dubbing.src.utils import create_directory_if_needed
 from ai_dubbing.src.logger import get_logger
 
 

--- a/ai_dubbing/src/cli.py
+++ b/ai_dubbing/src/cli.py
@@ -8,7 +8,7 @@ import argparse
 import time
 
 # 使用绝对导入
-from ai_dubbing.src.utils.common_utils import setup_project_path
+from ai_dubbing.src.utils import setup_project_path
 from ai_dubbing.src.config import PATH
 from ai_dubbing.src.parsers import SRTParser, TXTParser
 from ai_dubbing.src.strategies import get_strategy, list_available_strategies, get_strategy_description

--- a/ai_dubbing/src/utils/__init__.py
+++ b/ai_dubbing/src/utils/__init__.py
@@ -4,5 +4,25 @@
 提供项目中常用的工具函数和类
 """
 
-from .common_utils import *
-from ai_dubbing.src.optimizer.subtitle_optimizer import LLMContextOptimizer
+from .common_utils import (
+    setup_project_path,
+    validate_file_exists,
+    create_directory_if_needed,
+    format_duration,
+    format_progress_text,
+    ProgressLogger,
+    normalize_audio_data,
+    initialize_project,
+)
+
+__all__ = [
+    "setup_project_path",
+    "validate_file_exists",
+    "create_directory_if_needed",
+    "format_duration",
+    "format_progress_text",
+    "ProgressLogger",
+    "normalize_audio_data",
+    "initialize_project",
+]
+

--- a/ai_dubbing/validate_durations.py
+++ b/ai_dubbing/validate_durations.py
@@ -15,7 +15,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from ai_dubbing.src.parsers.srt_parser import SRTParser
-from ai_dubbing.src.optimizer.subtitle_optimizer import LLMContextOptimizer, SubtitleTimingConstants
+from ai_dubbing.src.optimizer.subtitle_optimizer import SubtitleTimingConstants
 from ai_dubbing.src.logger import get_logger
 
 


### PR DESCRIPTION
## Summary
- define explicit exports in `utils.__init__` and drop eager LLM imports
- import utilities via package root
- lazy-load `LLMContextOptimizer` where needed and remove unused imports

## Testing
- `python -m ai_dubbing.test.run_tests` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689ae2deb17c832b8ed21d4722755b81