### PR TITLE
Adjust setupFileUploads to avoid duplicate bindings

### DIFF
--- a/ai_dubbing/web/static/app.js
+++ b/ai_dubbing/web/static/app.js
@@ -688,11 +688,6 @@ async function loadConfig() {
       area.addEventListener('dragenter', (e) => e.preventDefault());
     });
 
-    // Setup input mode switching
-    setupInputMode();
-
-    // Setup text input character count
-    setupTextInput();
   }
 
   function handleFileSelection(event, area, fileType) {


### PR DESCRIPTION
## Summary
- remove redundant setupInputMode and setupTextInput invocations in setupFileUploads to avoid duplicate event bindings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccc1160f4c832b91611ca26790b0fc