### PR TITLE
Remove unused progress/download references

### DIFF
--- a/ai_dubbing/web/static/app.js
+++ b/ai_dubbing/web/static/app.js
@@ -4,10 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusTitle = document.getElementById('status-title');
   const statusMessage = document.getElementById('status-message');
   const progressContainer = document.getElementById('progress-container');
-  const progressFill = document.getElementById('progress-fill');
-  const progressText = document.getElementById('progress-text');
   const resultSection = document.getElementById('result-section');
-  const downloadLink = document.getElementById('download-link');
   const submitBtn = document.getElementById('submit-btn');
 
   // Optimization status elements

--- a/ai_dubbing/web/templates/index.html
+++ b/ai_dubbing/web/templates/index.html
@@ -496,9 +496,9 @@
         <!-- Progress Bar -->
         <div class="progress-container" id="progress-container" style="display: none;">
           <div class="progress-bar">
-            <div class="progress-fill" id="progress-fill"></div>
+            <div class="progress-fill"></div>
           </div>
-          <span class="progress-text" id="progress-text">0%</span>
+          <span class="progress-text">0%</span>
         </div>
 
         <!-- Result Section -->
@@ -507,7 +507,7 @@
             <i class="fas fa-check-circle success-icon"></i>
             <h3>处理完成！</h3>
             <p>您的文件已准备就绪</p>
-            <a href="#" id="download-link" class="download-btn" target="_blank">
+            <a href="#" class="download-btn" target="_blank">
               <i class="fas fa-download"></i>
               <span>下载结果</span>
             </a>


### PR DESCRIPTION
## Summary
- remove unused DOM queries for the legacy progress and download elements in the main app script
- drop obsolete IDs from the fallback progress bar and download link markup now that they are unused

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccc1182fbc832baae229a37fbdd372